### PR TITLE
Fix Amplify build settings

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -8,7 +8,7 @@ frontend:
       commands:
         - npm run build
   artifacts:
-    baseDirectory: out
+    baseDirectory: .next
     files:
       - '**/*'
   cache:

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   trailingSlash: true,
-  distDir: 'out',
   images: {
-    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
## Summary
- adjust `next.config.js` for serverless deployment
- update Amplify config to use `.next` build output

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873dc30043c8326aa05d9d35d4ad1f8