### PR TITLE
Fix Amplify build output directory

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -8,7 +8,7 @@ frontend:
       commands:
         - npm run build
   artifacts:
-    baseDirectory: out
+    baseDirectory: .next
     files:
       - '**/*'
   cache:

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   trailingSlash: true,
-  distDir: 'out',
   images: {
-    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
## Summary
- configure Amplify artifact directory to `.next`
- remove custom `distDir` and export settings from Next.js config

## Testing
- `npm ci` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6880d29a3e0c8326af02b44f2ae23595